### PR TITLE
Retry choco install step up to 10 times

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,10 +78,13 @@ jobs:
       run: brew install gcovr
 
     - name: Install OpenCppCoverage and add to PATH
+      uses: nick-fields/retry@v2
       if: matrix.type.name == 'Debug' && runner.os == 'Windows'
-      run: |
-        choco install OpenCppCoverage -y
-        echo "C:\Program Files\OpenCppCoverage" >> $env:GITHUB_PATH
+      with:
+        max_attempts: 10
+        command: |
+          choco install OpenCppCoverage -y
+          echo "C:\Program Files\OpenCppCoverage" >> $env:GITHUB_PATH
 
     - name: Configure CMake
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,7 @@ jobs:
       if: matrix.type.name == 'Debug' && runner.os == 'Windows'
       with:
         max_attempts: 10
+        timeout_minutes: 3
         command: |
           choco install OpenCppCoverage -y
           echo "C:\Program Files\OpenCppCoverage" >> $env:GITHUB_PATH


### PR DESCRIPTION
Frustrating having CI fail because this step sporadically fails

This change should make it retry up to 10 times when needed. Obviously hard to test without being able to cause a failure, but if it still goes wrong we can tweak as needed